### PR TITLE
Fix error mentioned in Video 7b

### DIFF
--- a/content/ch_07_mcast_ncs/ch_07_mcast_ncs.org
+++ b/content/ch_07_mcast_ncs/ch_07_mcast_ncs.org
@@ -173,7 +173,7 @@ m was previously transmitted by sender(m).
 
 - Sequence numbers
 - Acknowledgements and timeouts
-- Downside: Sender needs to know members of unicast group 
+- Downside: Sender needs to know members of multicast group 
   - Basically, replicated unicast
 
 


### PR DESCRIPTION
Mentioned at 9:16 in https://videos.uni-paderborn.de/channel/video/Verteilte-Systeme-Kapitel-7b-Reliable-multicast-ACK-implosion/163fa17a5802855a8c704dbe90a31dd2/43